### PR TITLE
Mass-assingment security and Rails 3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,34 @@
 PATH
   remote: .
   specs:
-    flipper-activerecord3dot2 (0.1.1)
-      activerecord (>= 3.2.21, < 4.2)
+    flipper-activerecord3dot2 (0.1.2)
+      activerecord (>= 3.2.21, < 4)
       flipper (~> 0.6)
       foreigner (~> 1.7, >= 1.7.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.1.13)
-      activesupport (= 4.1.13)
-      builder (~> 3.1)
-    activerecord (4.1.13)
-      activemodel (= 4.1.13)
-      activesupport (= 4.1.13)
-      arel (~> 5.0.0)
-    activesupport (4.1.13)
-      i18n (~> 0.6, >= 0.6.9)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.1)
-      tzinfo (~> 1.1)
-    arel (5.0.1.20140414130214)
-    builder (3.2.2)
+    activemodel (3.2.22)
+      activesupport (= 3.2.22)
+      builder (~> 3.0.0)
+    activerecord (3.2.22)
+      activemodel (= 3.2.22)
+      activesupport (= 3.2.22)
+      arel (~> 3.0.2)
+      tzinfo (~> 0.3.29)
+    activesupport (3.2.22)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
+    arel (3.0.3)
+    builder (3.0.4)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.0)
     database_cleaner (1.3.0)
     diff-lcs (1.2.5)
     ffi (1.9.5)
-    flipper (0.7.0)
+    flipper (0.7.1)
     foreigner (1.7.4)
       activerecord (>= 3.0.0)
     formatador (0.2.5)
@@ -48,14 +46,13 @@ GEM
       rspec (>= 2.14, < 4.0)
     hitimes (1.2.2)
     i18n (0.7.0)
-    json (1.8.3)
     listen (2.7.11)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.9)
     method_source (0.8.2)
-    minitest (5.8.0)
+    multi_json (1.11.2)
     pg (0.17.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -79,12 +76,10 @@ GEM
     rspec-support (3.1.1)
     slop (3.6.0)
     thor (0.19.1)
-    thread_safe (0.3.5)
     timecop (0.7.1)
     timers (4.0.1)
       hitimes
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
+    tzinfo (0.3.44)
 
 PLATFORMS
   ruby
@@ -102,4 +97,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.10.2
+   1.10.3

--- a/flipper-activerecord3dot2.gemspec
+++ b/flipper-activerecord3dot2.gemspec
@@ -4,14 +4,12 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Jesse Proudman", "Blake Gentry"]
   gem.email         = ["jproudman@bluebox.net", "blakesgentry@gmail.com"]
   gem.description   = %q{ActiveRecord 3.2 adapter for Flipper}
-  gem.summary       = <<-SUMMARY
-    A fork of flipper-activerecord which supports ActiveRecord 3.2 and ActiveRecord 4.1 with minimal changes.
-  SUMMARY
+  gem.summary       = %q{A fork of flipper-activerecord which supports ActiveRecord 3.2.}
   gem.homepage      = "https://github.com/jproudman/flipper-activerecord"
   gem.require_paths = ["lib"]
 
   gem.files = `git ls-files`.split(" ")
   gem.add_dependency 'flipper', '~> 0.6'
-  gem.add_runtime_dependency 'activerecord', '>= 3.2.21', '< 4.2'
+  gem.add_runtime_dependency 'activerecord', '>= 3.2.21', '< 4'
   gem.add_runtime_dependency 'foreigner', '~> 1.7', '>= 1.7.4'
 end

--- a/lib/flipper/activerecord/feature.rb
+++ b/lib/flipper/activerecord/feature.rb
@@ -3,6 +3,8 @@ module Flipper
     class Feature < ::ActiveRecord::Base
       self.table_name = "flipper_features"
 
+      attr_accessible :name
+
       has_many :gates, foreign_key: "flipper_feature_id", :dependent => :destroy
     end
   end

--- a/lib/flipper/activerecord/gate.rb
+++ b/lib/flipper/activerecord/gate.rb
@@ -3,6 +3,8 @@ module Flipper
     class Gate < ::ActiveRecord::Base
       self.table_name = "flipper_gates"
 
+      attr_accessible :name, :value
+
       belongs_to :feature, foreign_key: "flipper_feature_id"
     end
   end

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -7,3 +7,19 @@ describe Flipper::Adapters::ActiveRecord do
 
   it_should_behave_like 'a flipper adapter'
 end
+
+describe Flipper::ActiveRecord::Feature do
+  let(:mass_assignable_attributes) { described_class.attr_accessible[:default].to_a }
+
+  it 'restricts mass-assignment' do
+    expect(mass_assignable_attributes).to match_array %w(name)
+  end
+end
+
+describe Flipper::ActiveRecord::Gate do
+  let(:mass_assignable_attributes) { described_class.attr_accessible[:default].to_a }
+
+  it 'restricts mass-assignment' do
+    expect(mass_assignable_attributes).to match_array %w(name value)
+  end
+end


### PR DESCRIPTION
Hi there,

thank you very much for back-porting this gem. 

We have some trouble running it in our rails 3.2 environment because we set

```
config.active_record.whitelist_attributes = true
config.active_record.mass_assignment_sanitizer = :strict
```

This disables mass-assignment per default and prevents the gem for adding new feature flags.

With this PR we add `attr_accessible` to the active_record models, but this will break rails 4 support of this gem. I'd suggest to move rails 4 support into its own branch. What do you think?
